### PR TITLE
Improve tokenizer with BPE ranking and caching

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -323,6 +323,8 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.11.1")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))

--- a/app/src/test/java/com/example/androiddiffusion/ml/diffusers/TextTokenizerTest.kt
+++ b/app/src/test/java/com/example/androiddiffusion/ml/diffusers/TextTokenizerTest.kt
@@ -1,0 +1,42 @@
+package com.example.androiddiffusion.ml.diffusers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class TextTokenizerTest {
+    private lateinit var tokenizer: TextTokenizer
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        tokenizer = TextTokenizer(context)
+    }
+
+    @Test
+    fun `encode known sentence`() {
+        val ids = tokenizer.encode("a photo of a cat")
+        assertEquals(77, ids.size)
+        val expected = intArrayOf(49407, 97, 49406, 112, 104, 49406, 111, 49406, 49406, 49406, 97, 49406, 99, 49406, 49406)
+        assertContentEquals(expected, ids.sliceArray(0 until expected.size))
+    }
+
+    @Test
+    fun `encode second sentence`() {
+        val ids = tokenizer.encode("an astronaut riding a horse")
+        val expected = intArrayOf(49407, 49406, 49406, 97, 49406, 114, 49406, 97, 49406, 49406, 114, 49406, 49406, 103, 49406)
+        assertContentEquals(expected, ids.sliceArray(0 until expected.size))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `encode text exceeding max length`() {
+        val longText = List(80) { "word" }.joinToString(" ")
+        tokenizer.encode(longText)
+    }
+}


### PR DESCRIPTION
## Summary
- implement CLIP-style BPE ranking tokenizer with vocab/merge assets and caching
- validate token lengths and add Robolectric-based unit tests
- add test dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689798d360648323be9cdff72f358c5c